### PR TITLE
bump dependency version of jscodeshift dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "clone": "^2.1.2",
-    "jscodeshift": "^0.7.0",
+    "jscodeshift": "^0.13.1",
     "loader-utils": "^1.2.3",
     "querystring": "^0.2.0"
   },


### PR DESCRIPTION
## Related issues / Problem

The dependency jscodeshift version used currently seems to be outdated. The latest version of jscodeshift does not have breaking changes.

## What I did
Updated to the latest version of jscodeshift dependency.

## Checklist

> Please check below.

- [yes] Added one or more test
- [yes ] This PR does not includes any other changes that is unrelated to the problem/feature

## Additional notes
Please let me know if further clarification would be needed.