### PR TITLE
Replaced deprecated querystring with URLSearchParams and removed it from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   "dependencies": {
     "clone": "^2.1.2",
     "jscodeshift": "^0.13.1",
-    "loader-utils": "^1.2.3",
-    "querystring": "^0.2.0"
+    "loader-utils": "^1.2.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 const clone = require('clone')
 const docgen = require('vue-docgen-api')
 const loaderUtils = require('loader-utils')
-const qs = require('querystring')
 
 const inject = require('./inject')
 const { filterDescriptors } = require('./utils')
@@ -12,7 +11,9 @@ const defaultOptions = {
 
 module.exports = async function(content, map) {
   const callback = this.async()
-  const queries = qs.parse(this.resourceQuery.slice(1))
+  const queries = Object.fromEntries(
+    new URLSearchParams(this.resourceQuery.slice(1))
+  )
 
   // When vue-loader takes an input file (foo.vue), it calls itself multiple times
   // with same file with different queries. If there is 'vue' query, the import is


### PR DESCRIPTION
Hi guys!

This avoids the warning shown when installing deps
>npm WARN deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.